### PR TITLE
Update default list for the benchmarks

### DIFF
--- a/bench/bench.cc
+++ b/bench/bench.cc
@@ -60,7 +60,7 @@ static const std::string USAGE =
 
 // Default list of comma-separated operations to run
 static const char *FLAGS_benchmarks =
-        "fillrandom,overwrite,fillseq,readrandom,readseq,readrandom,readmissing,readrandom,deleteseq";
+        "fillseq,fillrandom,overwrite,readseq,readrandom,readmissing,deleteseq,deleterandom,readwhilewriting,readrandomwriterandom";
 
 // Default engine name
 static const char *FLAGS_engine = "pmkv";


### PR DESCRIPTION
The default list doesn't cover every benchmark option. 
The user who runs with the default command will not test all of them.